### PR TITLE
Include cabal file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ cabal.sandbox.config
 .stack-work/
 cabal.project.local
 .vagrant
-*.cabal

--- a/language-hcl.cabal
+++ b/language-hcl.cabal
@@ -1,0 +1,133 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 32de999bbde521dabe82f237151314a9715e2ceccc9eba2568d54484bbabc781
+
+name:           language-hcl
+version:        0.1.2.0
+synopsis:       HCL parsers and pretty-printers for the Haskell programming language.
+description:     @language-hcl@ contains HCL (Hashicorp Configuration Language) parsers and pretty-printers for the Haskell programming language.
+                "Data.HCL" exports all the API surface in the package. 
+category:       Data
+homepage:       https://github.com/beijaflor-io/haskell-language-hcl#readme
+bug-reports:    https://github.com/beijaflor-io/haskell-language-hcl/issues
+author:         Pedro Tacla Yamada
+maintainer:     tacla.yamada@gmail.com
+copyright:      Copyright (c) 2016 Pedro Tacla Yamada
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    ./test-fixtures/basic.hcl
+    ./test-fixtures/basic.json
+    ./test-fixtures/basic_int_string.hcl
+    ./test-fixtures/basic_squish.hcl
+    ./test-fixtures/decode_policy.hcl
+    ./test-fixtures/decode_policy.json
+    ./test-fixtures/decode_tf_variable.hcl
+    ./test-fixtures/decode_tf_variable.json
+    ./test-fixtures/empty.hcl
+    ./test-fixtures/escape.hcl
+    ./test-fixtures/flat.hcl
+    ./test-fixtures/float.hcl
+    ./test-fixtures/float.json
+    ./test-fixtures/interpolate_escape.hcl
+    ./test-fixtures/multiline.hcl
+    ./test-fixtures/multiline.json
+    ./test-fixtures/multiline_bad.hcl
+    ./test-fixtures/multiline_indented.hcl
+    ./test-fixtures/multiline_no_eof.hcl
+    ./test-fixtures/multiline_no_hanging_indent.hcl
+    ./test-fixtures/multiline_no_marker.hcl
+    ./test-fixtures/nested_block_comment.hcl
+    ./test-fixtures/nested_provider_bad.hcl
+    ./test-fixtures/object_list.json
+    ./test-fixtures/scientific.hcl
+    ./test-fixtures/scientific.json
+    ./test-fixtures/slice_expand.hcl
+    ./test-fixtures/structure.hcl
+    ./test-fixtures/structure.json
+    ./test-fixtures/structure2.hcl
+    ./test-fixtures/structure2.json
+    ./test-fixtures/structure_flat.json
+    ./test-fixtures/structure_flatmap.hcl
+    ./test-fixtures/structure_list.hcl
+    ./test-fixtures/structure_list.json
+    ./test-fixtures/structure_list_deep.json
+    ./test-fixtures/structure_multi.hcl
+    ./test-fixtures/structure_multi.json
+    ./test-fixtures/terraform_heroku.hcl
+    ./test-fixtures/terraform_heroku.json
+    ./test-fixtures/tfvars.hcl
+    ./test-fixtures/unterminated_block_comment.hcl
+    ./test-fixtures/unterminated_brace.hcl
+
+source-repository head
+  type: git
+  location: https://github.com/beijaflor-io/haskell-language-hcl
+
+library
+  exposed-modules:
+      Data.HCL
+      Data.HCL.Types
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.8 && <5
+    , deepseq
+    , directory >=1.2.2.0
+    , filepath >=1.4.0.0
+    , megaparsec >=6.2.0
+    , prettyprinter >=1.1.1
+    , scientific >=0.3.4.6
+    , semigroups >=0.18.1
+    , text >=1.2.2.1
+    , unordered-containers
+    , void
+  default-language: Haskell2010
+
+test-suite hspec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Data.HCL.PrettyPrintSpec
+      Data.HCL.TestHelper
+      Data.HCLSpec
+      SanitySpec
+      Paths_language_hcl
+  hs-source-dirs:
+      test
+  build-depends:
+      QuickCheck
+    , base
+    , directory
+    , filepath
+    , hspec
+    , hspec-megaparsec
+    , language-hcl
+    , megaparsec >=6.2.0
+    , prettyprinter >=1.1.1
+    , semigroups >=0.18.1
+    , text
+    , transformers >=0.4.2.0
+  default-language: Haskell2010
+
+benchmark hcl-benchmark
+  type: exitcode-stdio-1.0
+  main-is: HCLBenchmark.hs
+  other-modules:
+      Paths_language_hcl
+  hs-source-dirs:
+      bench
+  ghc-options: -O2 -threaded
+  build-depends:
+      base
+    , criterion
+    , directory
+    , filepath
+    , language-hcl
+    , text
+  default-language: Haskell2010


### PR DESCRIPTION
Without this, using the repo as an extra-dep will trigger a warning in
Stack 2.2.